### PR TITLE
Speed up steps to allow for faster demo

### DIFF
--- a/.github/workflows/python-ci.yml
+++ b/.github/workflows/python-ci.yml
@@ -9,7 +9,7 @@ on:
 
 jobs:
   build-and-run-pytest:
-  
+
     runs-on: ubuntu-latest
 
     steps:
@@ -26,7 +26,7 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip cython wheel
-        pip install -r requirements.txt
+        pip install -r tests/requirements.txt
 
     # 4. Build test image
     - name: Build test Docker image

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.10-bookworm
+FROM python:3.10-slim-bookworm
 
 # Copy and install requirements
 COPY requirements.txt requirements.txt

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 # Some example packages
-pandas
-numpy
-seaborn
+# pandas
+# numpy
+# seaborn
 
 # API-related packages
 fastapi

--- a/tests/Dockerfile.test
+++ b/tests/Dockerfile.test
@@ -1,4 +1,4 @@
-FROM python:3.10-bookworm
+FROM python:3.10-slim-bookworm
 
 # Copy and install requirements
 COPY requirements.txt requirements.txt

--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -1,0 +1,3 @@
+# Testing packages
+requests
+pytest


### PR DESCRIPTION
- Use a slim base image
- Remove unnecessary packages in the requirements.txt
- Separate requirements.txt for running the CI test (no need to install everything if we just need requests and pytest)